### PR TITLE
[FEATURE] Updated SnapLayout to remove negative usage

### DIFF
--- a/Example/SnapLayout/ViewController.swift
+++ b/Example/SnapLayout/ViewController.swift
@@ -12,7 +12,7 @@ import SnapLayout
 internal final class ViewController: UIViewController {
     
     struct Constants {
-        static let emojiLabelConstraintConstants = SnapConfig(top: 50, leading: 8, trailing: -8)
+        static let emojiLabelConstraintConstants = SnapConfig(top: 50, leading: 8, trailing: 8)
     }
     
     /// Container view encompassing all subviews of View Controller

--- a/Example/SnapLayout_ExampleTests/SnapLayoutTests.swift
+++ b/Example/SnapLayout_ExampleTests/SnapLayoutTests.swift
@@ -52,7 +52,7 @@ class SnapLayoutTests: BaseTestCase {
     /// Tests Snap Size method
     func testSnapSize() {
         let size = CGSize(width: 30, height: 40)
-        let snapManager = view.snapSize(size: size)
+        let snapManager = view.snap(size: size)
         XCTAssertEqual(view.translatesAutoresizingMaskIntoConstraints, false)
         XCTAssertNotNil(snapManager.width)
         XCTAssertNotNil(snapManager.height)

--- a/Example/SnapLayout_ExampleTests/SnapManagerTests.swift
+++ b/Example/SnapLayout_ExampleTests/SnapManagerTests.swift
@@ -208,7 +208,7 @@ class SnapManagerTests: BaseTestCase {
     func testSnapManagerSizeConstructor() {
         let bottomConstant = CGFloat(10)
         let size = CGSize(width: 30, height: 40)
-        let snapManager = childView.snap(bottom: bottomConstant).snapSize(size: size)
+        let snapManager = childView.snap(bottom: bottomConstant).snap(size: size)
         XCTAssertEqual(childView.translatesAutoresizingMaskIntoConstraints, false)
         XCTAssertNotNil(snapManager.bottom)
         XCTAssertNotNil(snapManager.width)

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ func snap(to view: UIView? = nil, top: CGFloat? = nil, leading: CGFloat? = nil, 
 func snap(to view: UIView? = nil, constants: SnapConfig) -> SnapManager
 func snapWidth(to view: UIView, multiplier: CGFloat = 1) -> SnapManager
 func snapHeight(to view: UIView, multiplier: CGFloat = 1) -> SnapManager
-func snapSize(size: CGSize) -> SnapManager
+func snap(size: CGSize) -> SnapManager
 func snap(trailingView: UIView, constant: CGFloat = 0) -> SnapManager
 func snap(leadingView: UIView, constant: CGFloat = 0) -> SnapManager
 func snap(bottomView: UIView, constant: CGFloat = 0) -> SnapManager

--- a/SnapLayout/Classes/SnapLayout.swift
+++ b/SnapLayout/Classes/SnapLayout.swift
@@ -54,11 +54,11 @@ public extension UIView {
             snapManager.leading?.isActive = true
         }
         if let bottom = bottom {
-            snapManager.bottom = bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: bottom)
+            snapManager.bottom = view.bottomAnchor.constraint(equalTo: bottomAnchor, constant: bottom)
             snapManager.bottom?.isActive = true
         }
         if let trailing = trailing {
-            snapManager.trailing = trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: trailing)
+            snapManager.trailing = view.trailingAnchor.constraint(equalTo: trailingAnchor, constant: trailing)
             snapManager.trailing?.isActive = true
         }
         if let centerX = centerX, centerX {
@@ -133,7 +133,7 @@ public extension UIView {
     /// - Parameter size: CGSize specifying width and height
     /// - Returns: SnapManager holding all the values associated with constraints
     @discardableResult
-    func snapSize(size: CGSize) -> SnapManager {
+    func snap(size: CGSize) -> SnapManager {
         return snap(width: size.width, height: size.height)
     }
     
@@ -147,7 +147,7 @@ public extension UIView {
     func snap(trailingView: UIView, constant: CGFloat = 0) -> SnapManager {
         translatesAutoresizingMaskIntoConstraints = false
         let snapManager = SnapManager(view: self)
-        snapManager.trailing = trailingAnchor.constraint(equalTo: trailingView.leadingAnchor, constant: constant)
+        snapManager.trailing = trailingView.leadingAnchor.constraint(equalTo: trailingAnchor, constant: constant)
         snapManager.trailing?.isActive = true
         return snapManager
     }
@@ -177,7 +177,7 @@ public extension UIView {
     func snap(bottomView: UIView, constant: CGFloat = 0) -> SnapManager {
         translatesAutoresizingMaskIntoConstraints = false
         let snapManager = SnapManager(view: self)
-        snapManager.bottom = bottomAnchor.constraint(equalTo: bottomView.topAnchor, constant: constant)
+        snapManager.bottom = bottomView.topAnchor.constraint(equalTo: bottomAnchor, constant: constant)
         snapManager.bottom?.isActive = true
         return snapManager
     }

--- a/SnapLayout/Classes/SnapManager.swift
+++ b/SnapLayout/Classes/SnapManager.swift
@@ -140,12 +140,12 @@ public class SnapManager {
     /// - Parameter size: CGSize specifying width and height
     /// - Returns: SnapManager holding all the values associated with constraints
     @discardableResult
-    public func snapSize(size: CGSize) -> SnapManager {
+    public func snap(size: CGSize) -> SnapManager {
         guard let weakView = weakView else {
             print("SnapLayout Error - Cannot apply constraint upon a view that is not retained")
             return SnapManager()
         }
-        let newSnapManager = weakView.snapSize(size: size)
+        let newSnapManager = weakView.snap(size: size)
         sync(with: newSnapManager)
         return self
     }


### PR DESCRIPTION
- Previously, bottom and trailing would cause views to overlap when using positive constant values
- Updated to take in positive inputs to gain distance between views
- Now negative inputs will mimic the same behavior as other snap methods
	- views will overlap if negative input
	- viwes will gain distance if positive input
- Update `snapSize(size: ...)` signature to `snap(size: ...)` to be more consistent with naming pattern